### PR TITLE
Removing odds n ends

### DIFF
--- a/common/aeon_archival_object_request.rb
+++ b/common/aeon_archival_object_request.rb
@@ -4,7 +4,7 @@ class AeonArchivalObjectRequest
   def self.citation(json, mapped)
     cite = ''
     if note = json['notes'].find{|n| n['type'] == 'prefercite'}
-      cite = note['subnotes'].map{|sn| sn['content']}.join('; ')
+      cite = note['subnotes'].map{|sn| sn['content'].strip}.join('; ')
     else
       cite = "#{json['component_id']}, " if json['component_id']
       cite += mapped['title']

--- a/common/aeon_archival_object_request.rb
+++ b/common/aeon_archival_object_request.rb
@@ -24,7 +24,7 @@ class AeonArchivalObjectRequest
       cite += ". #{mapped['collection_title']}, #{mapped['collection_id']}. #{mapped['repo_name']}."
     end
 
-    "#{cite}  #{AppConfig[:public_proxy_url]}#{json['uri']}  Accessed #{Time.now.strftime("%B %d, %Y")}"
+    "#{cite}"
   end
 
 

--- a/common/aeon_archival_object_request.rb
+++ b/common/aeon_archival_object_request.rb
@@ -86,7 +86,7 @@ class AeonArchivalObjectRequest
     out['ItemCitation'] = citation(json, out)
 
     out['ItemDate'] = json['dates'].map {|d|
-      I18n.t("enumerations.date_label.#{d['label']}") + '  ' + (d['expression'] || ([d['begin'], d['end']].compact.join(' - ')))
+      (d['expression'] || ([d['begin'], d['end']].compact.join(' - ')))
     }.join(', ')
 
     out['ItemInfo13'] = out['component_id']


### PR DESCRIPTION
I believe what I did here was to change things to remove content from the citation and the ItemDate.
In conversations we decided to have minimal citations (and now I know where to expand them if things reverse course). Though I was fairly confident on an intuitive level that the `"#{cite}"` at L27 could be removed also, I left it because I know that I don't know what downstream effects removing it might have.
The date doesn't need the role prepended.

No ego in this. If it's all a hash, let me know.