### PR TITLE
Changing submit text to convey process status

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -12,7 +12,7 @@ en:
       request_digital_copy_help_text: Obtain a digitized version of this item.
       select_all: Select All
       clear_all: Clear All
-      submit_request_label: Submit Request
+      submit_request_label: Continue
       close_popup_label: Cancel
       request_unavailable_warning: Record is not available for request.
       toggle_column_label: Toggle selection


### PR DESCRIPTION
Some patrons seemed to think "Submit Request" took care of everything and abandoned their requests. Intuition and our UX group think this will help.

I'm submitting the PR on principle, but if the change makes the plugin sufficiently non-generalizable, I'm happy to do this work in a Yale fork instead.